### PR TITLE
fix: X-button window close on Windows (#106)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1565,6 +1565,16 @@ fn get_boot_workspace() -> Option<String> {
 ///   not propagate the environment of the `open(1)` subprocess, so env vars
 ///   are not an option here).
 /// - Linux/Windows: via the `LOGGY_LOAD_WORKSPACE` env var.
+// Issue #106: On Windows, calling `window.close()` from inside a JS
+// `onCloseRequested` handler after `preventDefault()` is a no-op — the X
+// button appears dead. The native Exit menu works because it goes through
+// the menu's `.quit()` path. Mirror that here so the frontend can finalize
+// the close from JS after flushing pending writes.
+#[tauri::command]
+fn quit_app(app: AppHandle) {
+    app.exit(0);
+}
+
 #[tauri::command]
 fn open_new_window(workspace_id: Option<String>) -> Result<(), String> {
     let exe = std::env::current_exe().map_err(|e| format!("current_exe: {}", e))?;
@@ -2040,6 +2050,7 @@ pub fn run() {
             set_settings,
             open_new_window,
             get_boot_workspace,
+            quit_app,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, act } from "@testing-library/react";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { invoke } from "@tauri-apps/api/core";
 import App from "./App";
 
 const mockListen = vi.mocked(listen);
+const mockGetCurrentWindow = vi.mocked(getCurrentWindow);
+const mockInvoke = vi.mocked(invoke);
 
 describe("App - Tauri event listeners", () => {
   beforeEach(() => {
@@ -41,5 +45,64 @@ describe("App - Tauri event listeners", () => {
       const calls = mockListen.mock.calls.filter((c) => c[0] === event);
       expect(calls).toHaveLength(1);
     }
+  });
+});
+
+// Issue #106: Window close button (X) does nothing on Windows.
+//
+// Root cause: in Tauri v2 on Windows, calling `window.close()` from inside
+// an `onCloseRequested` handler after `preventDefault()` is silently
+// dropped. The Exit menu works because it goes through Rust's quit path.
+// Fix: route the final exit through a `quit_app` Tauri command that calls
+// `app.exit(0)`, matching the Exit menu's working path.
+describe("App - issue #106 X-button close", () => {
+  let closeRequestedHandler:
+    | ((event: { preventDefault: () => void }) => Promise<void> | void)
+    | null;
+  let closeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListen.mockImplementation(() => Promise.resolve(() => {}));
+    mockInvoke.mockImplementation(() => Promise.resolve([]));
+    closeRequestedHandler = null;
+    closeMock = vi.fn(() => Promise.resolve());
+
+    mockGetCurrentWindow.mockReturnValue({
+      startDragging: vi.fn(),
+      listen: vi.fn(() => Promise.resolve(() => {})),
+      setTitle: vi.fn(() => Promise.resolve()),
+      onCloseRequested: vi.fn((cb) => {
+        closeRequestedHandler = cb;
+        return Promise.resolve(() => {});
+      }),
+      close: closeMock,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+  });
+
+  it("invokes quit_app and does NOT call win.close() when X fires onCloseRequested", async () => {
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(closeRequestedHandler).not.toBeNull();
+
+    let defaultPrevented = false;
+    const fakeEvent = {
+      preventDefault: () => {
+        defaultPrevented = true;
+      },
+    };
+
+    await act(async () => {
+      await closeRequestedHandler!(fakeEvent);
+    });
+
+    expect(defaultPrevented).toBe(true);
+    // Fix for #106: finalize via Rust quit_app (works on Windows), not
+    // win.close() (silently dropped on Windows from inside the handler).
+    expect(mockInvoke).toHaveBeenCalledWith("quit_app");
+    expect(closeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,16 +144,17 @@ function App() {
   }, []);
 
   // Multi-process: block the window close long enough to flush pending
-  // debounced settings writes and auto-save the bound workspace. We must
-  // use `onCloseRequested` (not the generic `listen` API) because that's
-  // the only path that lets us `preventDefault()` and call `win.close()`
-  // explicitly after the async work finishes. Using `listen` here races
-  // the close and silently drops writes made in the last ~300ms.
+  // debounced settings writes and auto-save the bound workspace, then exit
+  // the process via the `quit_app` Tauri command. Issue #106: on Windows,
+  // calling `win.close()` from inside `onCloseRequested` after
+  // `preventDefault()` is silently dropped, so the X button does nothing.
+  // Routing the final exit through Rust's `app.exit(0)` matches the Exit
+  // menu path and works on every OS.
   useEffect(() => {
     const win = getCurrentWindow();
     let closing = false;
     const unlistenPromise = win.onCloseRequested(async (event) => {
-      if (closing) return; // our own `win.close()` below re-fires the event
+      if (closing) return;
       closing = true;
       event.preventDefault();
       try {
@@ -167,9 +168,9 @@ function App() {
         console.warn("close: flushPendingSettingsWrites failed:", e);
       }
       try {
-        await win.close();
+        await directInvoke("quit_app");
       } catch (e) {
-        console.warn("close: win.close() failed:", e);
+        console.warn("close: quit_app failed:", e);
       }
     });
     return () => {


### PR DESCRIPTION
## Summary

- On Windows, calling `window.close()` from inside `onCloseRequested` after `preventDefault()` is silently dropped — X button appears dead. The Exit menu works because it goes through the OS quit path.
- Adds a `quit_app` Tauri command (`app.exit(0)`) and routes the JS close handler through it after the existing async flush.
- Adds a regression test (`src/App.test.tsx`) asserting `invoke("quit_app")` is called and `win.close()` is not.

Closes #106

## Test plan

- [x] `npm test` — 149/149 passing, including the new `App - issue #106 X-button close` test
- [x] `cargo check` — clean
- [ ] **Smoke test on Windows:** click the X button on a packaged Windows build and confirm the app exits. Settings/workspace autosave should still run (preventDefault path is unchanged).
- [ ] macOS regression: Cmd-Q and red-traffic-light close both still work.