### PR TITLE
fix: show platform-appropriate keyboard shortcuts on Windows/Linux

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { useUpdateCheck } from "./hooks/useUpdateCheck";
 import { useSettingsStore, getLogLevelCssVars } from "./stores/settingsStore";
 import { useDemoStore } from "./demo/demoStore";
 import { useSystemTheme } from "./hooks/useSystemTheme";
+import { MOD_KEY, shortcut } from "./utils/platform";
 import "./App.css";
 
 interface ToastProps {
@@ -677,7 +678,7 @@ function App() {
               ? "hover:bg-gray-700 text-gray-400 hover:text-gray-200"
               : "hover:bg-gray-200 text-gray-500 hover:text-gray-700"
           }`}
-          title="Settings (Cmd-,)"
+          title={`Settings (${shortcut(",")})`}
         >
           <svg
             className="w-5 h-5"
@@ -793,7 +794,7 @@ function App() {
                   isDark ? "bg-gray-700" : "bg-gray-200"
                 }`}
               >
-                ⌘R
+                {`${MOD_KEY}R`}
               </kbd>{" "}
               to retry
             </p>

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { shortcut } from "../utils/platform";
 
 interface ContextMenuProps {
   x: number;
@@ -147,7 +148,7 @@ export function ContextMenu({
         onClick={() => handleItemClick(onCopy, copyDisabled)}
       >
         <span>{hasTextSelection ? "Copy selection" : "Copy"}</span>
-        <span className={shortcutClass}>Cmd+C</span>
+        <span className={shortcutClass}>{shortcut("C")}</span>
       </div>
 
       {/* Copy All (group headers only) */}
@@ -332,7 +333,7 @@ export function ContextMenu({
         onClick={() => handleItemClick(onRefresh)}
       >
         <span>Refresh</span>
-        <span className={shortcutClass}>Cmd+R</span>
+        <span className={shortcutClass}>{shortcut("R")}</span>
       </div>
 
       {/* Clear */}
@@ -342,7 +343,7 @@ export function ContextMenu({
         onClick={() => handleItemClick(onClear, clearDisabled)}
       >
         <span>Clear</span>
-        <span className={shortcutClass}>Cmd+K</span>
+        <span className={shortcutClass}>{shortcut("K")}</span>
       </div>
     </div>
   );

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -16,6 +16,7 @@ import { TimeRangePicker } from "./TimeRangePicker";
 import type { LogLevel, GroupByMode } from "../types";
 import { useDebounce } from "../hooks/useDebounce";
 import { useSystemTheme } from "../hooks/useSystemTheme";
+import { shortcut } from "../utils/platform";
 
 /** Delay in ms before filter text changes trigger log filtering */
 const FILTER_DEBOUNCE_MS = 300;
@@ -301,7 +302,7 @@ export function FilterBar({ hideGroupBy }: { hideGroupBy?: boolean } = {}) {
           onClick={clearLogs}
           disabled={logs.length === 0 || !isTailing}
           className={`p-1 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer ${isDark ? "hover:bg-gray-700 text-gray-400 hover:text-gray-200" : "hover:bg-gray-200 text-gray-500 hover:text-gray-700"}`}
-          title="Clear logs (⌘K)"
+          title={`Clear logs (${shortcut("K")})`}
         >
           <MdDeleteOutline className="w-4 h-4" />
         </button>

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,17 @@
+const detectIsMac = (): boolean => {
+  if (typeof navigator === "undefined") return true;
+  const platform =
+    (navigator as Navigator & { userAgentData?: { platform?: string } })
+      .userAgentData?.platform ??
+    navigator.platform ??
+    "";
+  if (platform) return /mac/i.test(platform);
+  return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent ?? "");
+};
+
+export const IS_MAC = detectIsMac();
+
+export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl";
+
+export const shortcut = (key: string): string =>
+  IS_MAC ? `${MOD_KEY}${key}` : `${MOD_KEY}+${key}`;


### PR DESCRIPTION
## Summary
- Connection error retry hint, settings/clear tooltips, and context-menu shortcut labels were hardcoded to macOS `⌘`/`Cmd+` notation. They now show `Ctrl`/`Ctrl+` on Windows and Linux.
- Added `src/utils/platform.ts` with `IS_MAC`, `MOD_KEY`, and a `shortcut(key)` helper using `navigator.userAgentData?.platform` with `navigator.platform` / userAgent fallbacks.
- Key handlers already accepted `metaKey || ctrlKey`, so only the displayed labels needed updating.

## Test plan
- [ ] On macOS: connection error shows `⌘R`; Settings button tooltip shows `⌘,`; Clear logs tooltip shows `⌘K`; context menu shows `⌘C` / `⌘R` / `⌘K`.
- [ ] On Windows/Linux: same affordances show `CtrlR`, `Ctrl+,`, `Ctrl+K`, `Ctrl+C`, `Ctrl+R`, `Ctrl+K`.
- [ ] `npm run fmt && npm run lint && npm run build` clean.