### PR TITLE
feat: backfill last 15 minutes of logs when entering LIVE mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,7 @@ The filter bar time quickfilter buttons are customizable in Settings (CMD-,):
 - `refreshConnection` store action calls `reconnect_aws` and re-fetches logs with current filters
 - Log cache limits configurable in Settings (default: 50,000 entries OR 100 MB)
 - Live tail uses CloudWatch StartLiveTail streaming API (1-second updates from AWS) with per-panel sessions
+- When LIVE is activated, the panel first backfills the last 15 minutes via `fetch_logs` (window includes a 2s overlap past `now` so events emitted while the stream is connecting are not lost at the seam — existing dedup handles overlap). Backfill failure is non-fatal: a toast shows "Backfill failed — streaming live only" and the stream still starts. SSO/credential errors during backfill route through `setConnectionFailed` and the stream does NOT start until reconnect completes.
 - Falls back to 1-second polling if streaming is unavailable or sampling detected (2-second overlap window prevents event gaps)
 - Sampling detection: if 500 events in one update, switches to polling from last clean timestamp
 - Stream error handling: session limit exceeded → polling with toast; permission denied → error dialog and stop; other errors → silent polling fallback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,10 @@ The filter bar time quickfilter buttons are customizable in Settings (CMD-,):
 - `refreshConnection` store action calls `reconnect_aws` and re-fetches logs with current filters
 - Log cache limits configurable in Settings (default: 50,000 entries OR 100 MB)
 - Live tail uses CloudWatch StartLiveTail streaming API (1-second updates from AWS) with per-panel sessions
-- When LIVE is activated, the panel first backfills the last 15 minutes via `fetch_logs` (window includes a 2s overlap past `now` so events emitted while the stream is connecting are not lost at the seam — existing dedup handles overlap). Backfill failure is non-fatal: a toast shows "Backfill failed — streaming live only" and the stream still starts. SSO/credential errors during backfill route through `setConnectionFailed` and the stream does NOT start until reconnect completes.
+- When LIVE is activated, the panel first backfills the last 15 minutes via `fetch_logs` before the streaming tail takes over.
+  - The backfill window includes a 2s overlap past `now` so events emitted while the stream is connecting are not lost at the seam — existing dedup (event_id, timestamp+message[:100]) handles the overlap.
+  - Backfill failure is non-fatal: a toast shows "Backfill failed — streaming live only" and the stream still starts.
+  - SSO/credential errors during backfill route through `setConnectionFailed` and the stream does NOT start until reconnect completes. `isTailing` stays `true` during the wait so the SSO refresh callback in `workspaceStore` resumes live tail automatically.
 - Falls back to 1-second polling if streaming is unavailable or sampling detected (2-second overlap window prevents event gaps)
 - Sampling detection: if 500 events in one update, switches to polling from last clean timestamp
 - Stream error handling: session limit exceeded → polling with toast; permission denied → error dialog and stop; other errors → silent polling fallback

--- a/src/stores/panelSlice.test.ts
+++ b/src/stores/panelSlice.test.ts
@@ -232,7 +232,11 @@ describe("panelSlice startTail backfill", () => {
 
     expect(setConnectionFailed).toHaveBeenCalled();
     expect(managerStart).not.toHaveBeenCalled();
-    expect(harness.panel.isTailing).toBe(false);
+    // `isTailing` stays true even after credential failure so the post-SSO
+    // refresh callback in workspaceStore restarts live tail on this panel.
+    // `tailManager` is null because the manager was never constructed.
+    expect(harness.panel.isTailing).toBe(true);
+    expect(harness.panel.tailManager).toBeNull();
   });
 
   it("seam dedup: stream event with same event_id is dropped by onNewLogs", async () => {
@@ -339,7 +343,7 @@ describe("panelSlice startTail backfill", () => {
     expect(managerStart).not.toHaveBeenCalled();
   });
 
-  it("rapid LIVE toggle: only the latest backfill starts a manager", async () => {
+  it("rapid LIVE toggle: second click during backfill is blocked by isTailing guard", async () => {
     const { invoke } = await import("../demo/demoInvoke");
     const resolvers: Array<(v: LogEvent[]) => void> = [];
     vi.mocked(invoke).mockImplementation((cmd: string) => {
@@ -352,20 +356,17 @@ describe("panelSlice startTail backfill", () => {
 
     const harness = makeHarness();
     harness.actions.startTail();
-    // Calling startTail again while isTailing is false (because backfill
-    // hasn't resolved yet) would launch a second backfill. The spec doesn't
-    // guard with isTailing on the second call, so the test verifies our
-    // fetchId-based defense: first resolve becomes stale.
+    // First call sets isTailing=true before awaiting backfill. The second
+    // call must hit the `if (panel.isTailing) return;` guard at the top of
+    // startTail and become a no-op — no second backfill, no wasted AWS call.
     harness.actions.startTail();
-    expect(resolvers).toHaveLength(2);
+    expect(resolvers).toHaveLength(1);
 
     resolvers[0]([makeEvent(1000, "hello", "e1")]);
-    resolvers[1]([makeEvent(2000, "world", "e2")]);
     await new Promise((r) => setTimeout(r, 10));
 
     expect(managerStart).toHaveBeenCalledTimes(1);
-    // Only logs from the latest fetch are present.
-    expect(harness.panel.logs.map((l) => l.event_id)).toEqual(["e2"]);
+    expect(harness.panel.logs.map((l) => l.event_id)).toEqual(["e1"]);
   });
 
   it("backfill timeout path: soft-fails to toast and starts manager (ENG-5)", async () => {

--- a/src/stores/panelSlice.test.ts
+++ b/src/stores/panelSlice.test.ts
@@ -113,6 +113,17 @@ function makeEvent(ts: number, message: string, event_id?: string): LogEvent {
   } as LogEvent;
 }
 
+// Flush all pending microtasks so promise chains settle deterministically.
+// Used in negative-assertion tests ("X did NOT happen") where vi.waitFor
+// can't help — there's no positive condition to await. Three Promise.resolve
+// turns covers the longest chain in startTail() (Promise.race → catch →
+// post-backfill check → return).
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────
 
 describe("panelSlice startTail backfill", () => {
@@ -227,10 +238,8 @@ describe("panelSlice startTail backfill", () => {
 
     const harness = makeHarness();
     harness.actions.startTail();
-    // Give the rejected promise a chance to settle.
-    await new Promise((r) => setTimeout(r, 10));
+    await vi.waitFor(() => expect(setConnectionFailed).toHaveBeenCalled());
 
-    expect(setConnectionFailed).toHaveBeenCalled();
     expect(managerStart).not.toHaveBeenCalled();
     // `isTailing` stays true even after credential failure so the post-SSO
     // refresh callback in workspaceStore restarts live tail on this panel.
@@ -292,7 +301,7 @@ describe("panelSlice startTail backfill", () => {
     // Simulate a competing action that bumps currentFetchId.
     harness.panel.currentFetchId += 1;
     resolveFetch([makeEvent(1000, "hello", "e1")]);
-    await new Promise((r) => setTimeout(r, 10));
+    await flushMicrotasks();
 
     expect(managerStart).not.toHaveBeenCalled();
     // Stale logs were NOT applied.
@@ -315,7 +324,7 @@ describe("panelSlice startTail backfill", () => {
     // User clicks Stop while backfill is pending.
     harness.actions.stopTail();
     resolveFetch([makeEvent(1000, "hello", "e1")]);
-    await new Promise((r) => setTimeout(r, 10));
+    await flushMicrotasks();
 
     expect(managerStart).not.toHaveBeenCalled();
     expect(harness.panel.isTailing).toBe(false);
@@ -338,7 +347,7 @@ describe("panelSlice startTail backfill", () => {
     harness.panel.logGroupName = "/aws/lambda/other";
     harness.panel.currentFetchId += 1;
     resolveFetch([makeEvent(1000, "hello", "e1")]);
-    await new Promise((r) => setTimeout(r, 10));
+    await flushMicrotasks();
 
     expect(managerStart).not.toHaveBeenCalled();
   });
@@ -363,9 +372,7 @@ describe("panelSlice startTail backfill", () => {
     expect(resolvers).toHaveLength(1);
 
     resolvers[0]([makeEvent(1000, "hello", "e1")]);
-    await new Promise((r) => setTimeout(r, 10));
-
-    expect(managerStart).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(managerStart).toHaveBeenCalledTimes(1));
     expect(harness.panel.logs.map((l) => l.event_id)).toEqual(["e1"]);
   });
 

--- a/src/stores/panelSlice.test.ts
+++ b/src/stores/panelSlice.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createPanelState,
+  createPanelActions,
+  type PanelState,
+  type PanelActions,
+} from "./panelSlice";
+import type { LogEvent } from "../types";
+
+// ── Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("../demo/demoInvoke", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("./settingsStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./settingsStore")>();
+  return {
+    ...actual,
+    useSettingsStore: {
+      getState: vi.fn(() => ({
+        logLevels: [],
+        cacheLimits: { maxLogCount: 50_000, maxSizeMb: 100 },
+        setLastSelectedLogGroup: vi.fn(),
+        setPanelPersistedConfig: vi.fn(),
+        setPersistedTimeRange: vi.fn(),
+        setPersistedDisabledLevels: vi.fn(),
+        setPersistedGroupFilter: vi.fn(),
+        setPersistedGroupByMode: vi.fn(),
+        clearPanelPersistedConfig: vi.fn(),
+        getDefaultDisabledLevels: vi.fn(() => new Set()),
+      })),
+    },
+  };
+});
+
+vi.mock("./connectionStore", () => ({
+  useConnectionStore: {
+    getState: vi.fn(() => ({
+      logGroups: [
+        {
+          name: "/aws/lambda/my-function",
+          arn: "arn:aws:logs:us-east-1:123:log-group:/aws/lambda/my-function",
+        },
+      ],
+      setConnectionFailed: vi.fn(),
+    })),
+  },
+}));
+
+// LiveTailManager is mocked so we can inspect start() calls without real AWS.
+const managerStart = vi.fn();
+const managerStop = vi.fn();
+const managerResetStart = vi.fn();
+const managerInstances: Array<{
+  start: typeof managerStart;
+  stop: typeof managerStop;
+  resetStartTimestamp: typeof managerResetStart;
+  options: Record<string, unknown>;
+}> = [];
+
+vi.mock("./LiveTailManager", () => {
+  class MockLiveTailManager {
+    options: Record<string, unknown>;
+    start = managerStart;
+    stop = managerStop;
+    resetStartTimestamp = managerResetStart;
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      managerInstances.push(this as unknown as (typeof managerInstances)[0]);
+    }
+  }
+  return { LiveTailManager: MockLiveTailManager };
+});
+
+// ── Test harness ──────────────────────────────────────────────────────
+
+interface Harness {
+  panel: PanelState;
+  actions: PanelActions;
+  setPanelCalls: Array<Partial<PanelState>>;
+}
+
+function makeHarness(initial: Partial<PanelState> = {}): Harness {
+  const state: PanelState = {
+    ...createPanelState("panel-1"),
+    logGroupName: "/aws/lambda/my-function",
+    ...initial,
+  };
+  const setPanelCalls: Array<Partial<PanelState>> = [];
+  const harness: Harness = {
+    panel: state,
+    actions: null as unknown as PanelActions,
+    setPanelCalls,
+  };
+  harness.actions = createPanelActions(
+    "panel-1",
+    () => harness.panel,
+    (partial) => {
+      setPanelCalls.push(partial);
+      Object.assign(harness.panel, partial);
+    },
+  );
+  return harness;
+}
+
+function makeEvent(ts: number, message: string, event_id?: string): LogEvent {
+  return {
+    timestamp: ts,
+    message,
+    log_stream_name: "stream-1",
+    event_id: event_id ?? null,
+  } as LogEvent;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("panelSlice startTail backfill", () => {
+  beforeEach(() => {
+    managerInstances.length = 0;
+    managerStart.mockReset();
+    managerStop.mockReset();
+    managerResetStart.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invokes fetch_logs with a ~15m + overlap window before starting tail", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs") return Promise.resolve([]);
+      if (cmd === "cancel_fetch") return Promise.resolve();
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    await vi.waitFor(() => expect(managerStart).toHaveBeenCalledTimes(1));
+
+    const fetchCall = vi
+      .mocked(invoke)
+      .mock.calls.find((c) => c[0] === "fetch_logs");
+    expect(fetchCall).toBeDefined();
+    const args = fetchCall![1] as Record<string, unknown>;
+    expect(args.logGroupName).toBe("/aws/lambda/my-function");
+    expect(args.filterPattern).toBeNull();
+    const span = (args.endTime as number) - (args.startTime as number);
+    // 15m + ~2s overlap, allow a little jitter for the second clock read.
+    expect(span).toBeGreaterThanOrEqual(15 * 60 * 1000 + 1500);
+    expect(span).toBeLessThanOrEqual(15 * 60 * 1000 + 5_000);
+  });
+
+  it("populates logs before manager.start() is called", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    let resolveFetch!: (v: LogEvent[]) => void;
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return new Promise<LogEvent[]>((resolve) => {
+          resolveFetch = resolve;
+        });
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+
+    // Manager not yet constructed: backfill still pending.
+    expect(managerStart).not.toHaveBeenCalled();
+    expect(harness.panel.logs).toHaveLength(0);
+
+    resolveFetch([makeEvent(1000, "hello", "e1")]);
+    await vi.waitFor(() => expect(managerStart).toHaveBeenCalledTimes(1));
+
+    // Logs were set before manager construction.
+    expect(harness.panel.logs).toHaveLength(1);
+    expect(harness.panel.isTailing).toBe(true);
+  });
+
+  it("sets isTailing true after backfill + manager.start", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    vi.mocked(invoke).mockResolvedValue([]);
+    const harness = makeHarness();
+    harness.actions.startTail();
+    await vi.waitFor(() => expect(managerStart).toHaveBeenCalled());
+    expect(harness.panel.isTailing).toBe(true);
+    expect(harness.panel.tailManager).not.toBeNull();
+  });
+
+  it("on generic backfill error: shows toast, manager still starts", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs") return Promise.reject(new Error("boom"));
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    await vi.waitFor(() => expect(managerStart).toHaveBeenCalledTimes(1));
+
+    expect(harness.panel.tailToast).toMatch(/backfill failed/i);
+    expect(harness.panel.isTailing).toBe(true);
+  });
+
+  it("on credential error: routes to setConnectionFailed and does NOT start manager", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    const { useConnectionStore } = await import("./connectionStore");
+    const setConnectionFailed = vi.fn();
+    vi.mocked(useConnectionStore.getState).mockReturnValue({
+      logGroups: [
+        {
+          name: "/aws/lambda/my-function",
+          arn: "arn:aws:logs:us-east-1:123:log-group:/aws/lambda/my-function",
+        },
+      ],
+      setConnectionFailed,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return Promise.reject(
+          new Error("ExpiredToken: token has expired (SSO)"),
+        );
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    // Give the rejected promise a chance to settle.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(setConnectionFailed).toHaveBeenCalled();
+    expect(managerStart).not.toHaveBeenCalled();
+    expect(harness.panel.isTailing).toBe(false);
+  });
+
+  it("seam dedup: stream event with same event_id is dropped by onNewLogs", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return Promise.resolve([makeEvent(1000, "hello", "e1")]);
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    await vi.waitFor(() => expect(managerStart).toHaveBeenCalledTimes(1));
+
+    const inst = managerInstances[0];
+    const onNewLogs = inst.options.onNewLogs as (logs: LogEvent[]) => void;
+    // Same event_id arrives via stream — should be dropped.
+    onNewLogs([makeEvent(1000, "hello", "e1")]);
+    expect(harness.panel.logs).toHaveLength(1);
+  });
+
+  it("seam dedup: stream event with same timestamp+message[:100] is dropped", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return Promise.resolve([makeEvent(2000, "request id abc-123 done")]);
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    await vi.waitFor(() => expect(managerStart).toHaveBeenCalledTimes(1));
+
+    const inst = managerInstances[0];
+    const onNewLogs = inst.options.onNewLogs as (logs: LogEvent[]) => void;
+    onNewLogs([makeEvent(2000, "request id abc-123 done")]);
+    expect(harness.panel.logs).toHaveLength(1);
+  });
+
+  it("stale fetchId on backfill success: result discarded, manager NOT started", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    let resolveFetch!: (v: LogEvent[]) => void;
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return new Promise<LogEvent[]>((resolve) => {
+          resolveFetch = resolve;
+        });
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    // Simulate a competing action that bumps currentFetchId.
+    harness.panel.currentFetchId += 1;
+    resolveFetch([makeEvent(1000, "hello", "e1")]);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(managerStart).not.toHaveBeenCalled();
+    // Stale logs were NOT applied.
+    expect(harness.panel.logs).toHaveLength(0);
+  });
+
+  it("stopTail during in-flight backfill: prevents manager.start (ENG-2)", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    let resolveFetch!: (v: LogEvent[]) => void;
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return new Promise<LogEvent[]>((resolve) => {
+          resolveFetch = resolve;
+        });
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    // User clicks Stop while backfill is pending.
+    harness.actions.stopTail();
+    resolveFetch([makeEvent(1000, "hello", "e1")]);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(managerStart).not.toHaveBeenCalled();
+    expect(harness.panel.isTailing).toBe(false);
+  });
+
+  it("log group switch during backfill: stale resolve does not start manager (ENG-4)", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    let resolveFetch!: (v: LogEvent[]) => void;
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return new Promise<LogEvent[]>((resolve) => {
+          resolveFetch = resolve;
+        });
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    // Caller changes log group mid-backfill.
+    harness.panel.logGroupName = "/aws/lambda/other";
+    harness.panel.currentFetchId += 1;
+    resolveFetch([makeEvent(1000, "hello", "e1")]);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(managerStart).not.toHaveBeenCalled();
+  });
+
+  it("rapid LIVE toggle: only the latest backfill starts a manager", async () => {
+    const { invoke } = await import("../demo/demoInvoke");
+    const resolvers: Array<(v: LogEvent[]) => void> = [];
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return new Promise<LogEvent[]>((resolve) => {
+          resolvers.push(resolve);
+        });
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    // Calling startTail again while isTailing is false (because backfill
+    // hasn't resolved yet) would launch a second backfill. The spec doesn't
+    // guard with isTailing on the second call, so the test verifies our
+    // fetchId-based defense: first resolve becomes stale.
+    harness.actions.startTail();
+    expect(resolvers).toHaveLength(2);
+
+    resolvers[0]([makeEvent(1000, "hello", "e1")]);
+    resolvers[1]([makeEvent(2000, "world", "e2")]);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(managerStart).toHaveBeenCalledTimes(1);
+    // Only logs from the latest fetch are present.
+    expect(harness.panel.logs.map((l) => l.event_id)).toEqual(["e2"]);
+  });
+
+  it("backfill timeout path: soft-fails to toast and starts manager (ENG-5)", async () => {
+    // The production code wraps the invoke in Promise.race with a 15s
+    // timeout that rejects with `Error("backfill timeout")`. We assert
+    // the timeout path is handled identically to a generic failure by
+    // simulating the same error rather than waiting 15s of fake time —
+    // the fake-timer + microtask interaction is too brittle to test
+    // the race wiring directly here.
+    const { invoke } = await import("../demo/demoInvoke");
+    vi.mocked(invoke).mockImplementation((cmd: string) => {
+      if (cmd === "fetch_logs")
+        return Promise.reject(new Error("backfill window exceeded"));
+      return Promise.resolve();
+    });
+
+    const harness = makeHarness();
+    harness.actions.startTail();
+    await vi.waitFor(() => expect(managerStart).toHaveBeenCalledTimes(1));
+
+    expect(harness.panel.tailToast).toMatch(/backfill failed/i);
+    expect(harness.panel.isTailing).toBe(true);
+  });
+});

--- a/src/stores/panelSlice.ts
+++ b/src/stores/panelSlice.ts
@@ -409,7 +409,17 @@ export function createPanelActions(
       }
 
       // Clear existing logs — live tail starts fresh, then backfills.
+      // `isTailing` becomes true as soon as the user expresses live intent,
+      // even before the manager is constructed. This way:
+      //   1) The guard at the top of `startTail()` blocks parallel backfills
+      //      when the user rapidly clicks LIVE during a slow backfill.
+      //   2) The post-SSO-refresh restart loop in workspaceStore.ts (which
+      //      checks `panel.isTailing`) will resume live tail on panels whose
+      //      backfill failed with a credential error mid-flight.
+      // Downstream consumers should treat `isTailing && !tailManager` as
+      // "backfilling, manager not yet started".
       setPanel({
+        isTailing: true,
         isLoading: true,
         logs: [],
         filteredLogs: [],
@@ -438,20 +448,25 @@ export function createPanelActions(
       });
 
       let backfillFailedFatally = false;
+      // Track the timeout handle so we can cancel it on success. Without
+      // this, every successful backfill leaks a pending setTimeout that
+      // fires 15s later and produces an unhandled rejection.
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
       try {
         const rawLogs = await Promise.race<LogEvent[]>([
           backfillInvoke,
-          new Promise<LogEvent[]>((_, reject) =>
+          new Promise<LogEvent[]>((_, reject) => {
             // Do not include the word "timeout" — it would match
             // `isConnectionOrCredentialError` and falsely trigger an SSO
             // refresh prompt. A backfill that exceeds the window is a
             // soft local failure, not a credential problem.
-            setTimeout(
+            timeoutHandle = setTimeout(
               () => reject(new Error("backfill window exceeded")),
               BACKFILL_TIMEOUT_MS,
-            ),
-          ),
+            );
+          }),
         ]);
+        if (timeoutHandle) clearTimeout(timeoutHandle);
 
         // Stale-result guard: matches `fetchLogs` at panelSlice.ts:240. If
         // another action bumped `currentFetchId` (stopTail, log-group switch,
@@ -484,6 +499,7 @@ export function createPanelActions(
           isLoading: false,
         });
       } catch (error) {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
         const message = error instanceof Error ? error.message : String(error);
         // Credential errors route through the connection store so SSO refresh
         // can run; live tail is blocked until reconnect completes.

--- a/src/stores/panelSlice.ts
+++ b/src/stores/panelSlice.ts
@@ -7,6 +7,14 @@ import { FilterCache } from "../utils/logFiltering";
 import { isConnectionOrCredentialError } from "../utils/connectionErrors";
 import { useConnectionStore } from "./connectionStore";
 
+const BACKFILL_WINDOW_MS = 15 * 60 * 1000;
+// Overlap the backfill window past `Date.now()` so events emitted between
+// the fetch completing and the live-tail stream activating are captured by
+// the backfill instead of dropped at the seam. Existing dedup handles
+// overlap; gaps would silently lose events.
+const BACKFILL_SEAM_OVERLAP_MS = 2000;
+const BACKFILL_TIMEOUT_MS = 15_000;
+
 /** Runtime state for a single panel */
 export interface PanelState {
   // Identity
@@ -378,13 +386,19 @@ export function createPanelActions(
       }
     },
 
-    startTail: () => {
+    startTail: async () => {
       const panel = safeGet();
       if (!panel.logGroupName) return;
       if (panel.isTailing) return;
 
-      // Cancel any in-flight fetch requests
-      setPanel({ currentFetchId: panel.currentFetchId + 1 });
+      const capturedLogGroupName = panel.logGroupName;
+
+      // Cancel any in-flight fetch requests and claim a fresh fetchId. The
+      // backfill below participates in the same `currentFetchId` counter as
+      // `fetchLogs()`, so any later action (`stopTail`, log-group switch,
+      // preset switch, rapid LIVE re-toggle) invalidates this attempt.
+      const fetchId = panel.currentFetchId + 1;
+      setPanel({ currentFetchId: fetchId });
       invoke("cancel_fetch", { panelId }).catch((e) => {
         console.debug("[Backend Activity] cancel_fetch:", e);
       });
@@ -394,24 +408,126 @@ export function createPanelActions(
         panel.tailManager.stop();
       }
 
-      // Clear existing logs — live tail starts fresh
+      // Clear existing logs — live tail starts fresh, then backfills.
       setPanel({
-        isLoading: false,
+        isLoading: true,
         logs: [],
         filteredLogs: [],
         expandedLogIndex: null,
         selectedLogIndex: null,
         isFollowing: true,
+        tailManager: null,
+        activeTransport: null,
       });
+
+      // Backfill: fetch the last 15 minutes (+ a 2s overlap past `now` so
+      // events emitted while the stream is connecting are not lost at the
+      // seam — existing dedup in `onNewLogs` handles the overlap).
+      const { cacheLimits } = useSettingsStore.getState();
+      const backfillStart = Date.now() - BACKFILL_WINDOW_MS;
+      const backfillEnd = Date.now() + BACKFILL_SEAM_OVERLAP_MS;
+      const backfillInvoke = invoke<LogEvent[]>("fetch_logs", {
+        panelId,
+        logGroupName: capturedLogGroupName,
+        startTime: backfillStart,
+        endTime: backfillEnd,
+        filterPattern: null,
+        maxCount: cacheLimits.maxLogCount,
+        maxSizeMb: cacheLimits.maxSizeMb,
+        fetchId,
+      });
+
+      let backfillFailedFatally = false;
+      try {
+        const rawLogs = await Promise.race<LogEvent[]>([
+          backfillInvoke,
+          new Promise<LogEvent[]>((_, reject) =>
+            // Do not include the word "timeout" — it would match
+            // `isConnectionOrCredentialError` and falsely trigger an SSO
+            // refresh prompt. A backfill that exceeds the window is a
+            // soft local failure, not a credential problem.
+            setTimeout(
+              () => reject(new Error("backfill window exceeded")),
+              BACKFILL_TIMEOUT_MS,
+            ),
+          ),
+        ]);
+
+        // Stale-result guard: matches `fetchLogs` at panelSlice.ts:240. If
+        // another action bumped `currentFetchId` (stopTail, log-group switch,
+        // preset switch), discard and bail — do not start the manager.
+        const current = getPanel();
+        if (
+          !current ||
+          fetchId !== current.currentFetchId ||
+          current.logGroupName !== capturedLogGroupName
+        ) {
+          console.log(`[Panel ${panelId}] Discarding stale backfill results`);
+          return;
+        }
+
+        const mergedLogs = mergeFragmentedLogs(rawLogs);
+        const parsedLogs = mergedLogs.map(parseLogEvent);
+        const filtered = current.filterCache.getFilteredLogs(
+          parsedLogs,
+          current.filterText,
+          current.disabledLevels,
+        );
+        const totalSize = mergedLogs.reduce(
+          (sum, log) => sum + log.message.length,
+          0,
+        );
+        setPanel({
+          logs: parsedLogs,
+          filteredLogs: filtered,
+          totalSizeBytes: totalSize,
+          isLoading: false,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // Credential errors route through the connection store so SSO refresh
+        // can run; live tail is blocked until reconnect completes.
+        if (isConnectionOrCredentialError(message)) {
+          useConnectionStore.getState().setConnectionFailed(message);
+          backfillFailedFatally = true;
+        } else {
+          // Generic backfill failure is non-fatal — toast and proceed to
+          // stream-only. Matches the design: "live tail must not be blocked
+          // by backfill failure."
+          setPanel({
+            tailToast: "Backfill failed — streaming live only",
+            isLoading: false,
+          });
+          setTimeout(() => {
+            const p = getPanel();
+            if (p && p.tailToast === "Backfill failed — streaming live only") {
+              setPanel({ tailToast: null });
+            }
+          }, 5000);
+        }
+      }
+
+      // Bail if the backfill ended in a fatal error, or if any concurrent
+      // action invalidated this attempt while we were awaiting.
+      const postBackfill = getPanel();
+      if (
+        backfillFailedFatally ||
+        !postBackfill ||
+        fetchId !== postBackfill.currentFetchId ||
+        postBackfill.logGroupName !== capturedLogGroupName
+      ) {
+        setPanel({ isLoading: false });
+        return;
+      }
 
       // Resolve ARN for streaming
       const { logGroups } = useConnectionStore.getState();
       const logGroupArn =
-        logGroups.find((g) => g.name === panel.logGroupName)?.arn ?? null;
+        logGroups.find((g) => g.name === capturedLogGroupName)?.arn ?? null;
 
       const manager = new LiveTailManager({
         panelId,
-        logGroupName: panel.logGroupName,
+        logGroupName: capturedLogGroupName,
         logGroupArn,
         onNewLogs: (newLogs: LogEvent[]) => {
           const current = getPanel();
@@ -484,7 +600,7 @@ export function createPanelActions(
 
       manager.start();
 
-      setPanel({ isTailing: true, tailManager: manager });
+      setPanel({ isTailing: true, tailManager: manager, isLoading: false });
 
       // Defer settings persistence to avoid cross-store render tearing
       setTimeout(() => {
@@ -503,7 +619,11 @@ export function createPanelActions(
       if (panel?.tailManager) {
         panel.tailManager.stop();
       }
+      // Bump fetchId so any in-flight backfill from startTail() is
+      // invalidated. Without this, a backfill that resolves after stopTail()
+      // could still construct and start a new manager.
       setPanel({
+        currentFetchId: (panel?.currentFetchId ?? 0) + 1,
         isTailing: false,
         tailManager: null,
         activeTransport: null,

--- a/src/stores/panelSlice.ts
+++ b/src/stores/panelSlice.ts
@@ -14,6 +14,11 @@ const BACKFILL_WINDOW_MS = 15 * 60 * 1000;
 // overlap; gaps would silently lose events.
 const BACKFILL_SEAM_OVERLAP_MS = 2000;
 const BACKFILL_TIMEOUT_MS = 15_000;
+// How many of the most recent events to check for stream/backfill dedup.
+// Bounded so onNewLogs stays O(window) even when logs holds the 50k-event
+// backfill — streaming dedup only matters against very recent events near
+// the seam, never against events from minutes ago.
+const DEDUP_WINDOW_SIZE = 500;
 
 /** Runtime state for a single panel */
 export interface PanelState {
@@ -417,7 +422,14 @@ export function createPanelActions(
       //      checks `panel.isTailing`) will resume live tail on panels whose
       //      backfill failed with a credential error mid-flight.
       // Downstream consumers should treat `isTailing && !tailManager` as
-      // "backfilling, manager not yet started".
+      // one of two transient states:
+      //   - backfill is in flight, manager not yet constructed (the common
+      //     case while `isLoading: true`), OR
+      //   - backfill ended with a credential error and the panel is waiting
+      //     for SSO refresh to retrigger startTail (isLoading: false).
+      // A future `tailStatus: 'backfilling' | 'credential_error' | 'live'`
+      // field would disambiguate these for UI affordances like a "reconnecting"
+      // spinner; today the two states are distinguishable via `isLoading`.
       setPanel({
         isTailing: true,
         isLoading: true,
@@ -446,6 +458,11 @@ export function createPanelActions(
         maxSizeMb: cacheLimits.maxSizeMb,
         fetchId,
       });
+      // If the timeout wins the Promise.race below, the backfillInvoke
+      // promise is still pending. A later rejection (network error after
+      // the timeout fired) would surface as an UnhandledPromiseRejection.
+      // Attach a no-op catch so the abandoned branch settles cleanly.
+      backfillInvoke.catch(() => {});
 
       let backfillFailedFatally = false;
       // Track the timeout handle so we can cancel it on success. Without
@@ -549,14 +566,17 @@ export function createPanelActions(
           const current = getPanel();
           if (!current) return; // Panel was closed
 
-          // Deduplicate
+          // Deduplicate against the most recent DEDUP_WINDOW_SIZE events
+          // only. Streamed events arrive at most ~1s apart and only collide
+          // with backfill events near the seam, so checking the full log
+          // history (up to 50k entries after backfill) on every callback
+          // is wasted O(n) work.
+          const dedupWindow = current.logs.slice(-DEDUP_WINDOW_SIZE);
           const existingIds = new Set(
-            current.logs.map((l) => l.event_id).filter(Boolean),
+            dedupWindow.map((l) => l.event_id).filter(Boolean),
           );
           const existingKeys = new Set(
-            current.logs.map(
-              (l) => `${l.timestamp}:${l.message.slice(0, 100)}`,
-            ),
+            dedupWindow.map((l) => `${l.timestamp}:${l.message.slice(0, 100)}`),
           );
           const uniqueNewLogs = newLogs.filter((log) => {
             if (log.event_id && existingIds.has(log.event_id)) return false;


### PR DESCRIPTION
## Summary

When the user toggles LIVE in a panel, populate the last 15 minutes of logs from the selected group before the streaming tail takes over. The viewer is no longer empty for the seconds-to-minutes it can take low-traffic groups to emit their first event.

**What this delivers:**
- Inline `invoke("fetch_logs")` in `startTail()` with a 15m + 2s overlap window so events emitted while the stream is connecting are captured by existing dedup (no seam gap).
- `Promise.race` with a 15s timeout. On timeout or generic failure, toast "Backfill failed — streaming live only" and still start the stream. SSO/credential errors route through `setConnectionFailed` and block the stream until reconnect — and now the SSO refresh callback resumes live tail on these panels.
- Stale-result guards: re-check `currentFetchId` and `logGroupName` after backfill resolves; bail if either changed.
- `stopTail()` bumps `currentFetchId` so Stop during in-flight backfill cancels the pending tail-start.
- `isTailing` is set true at the start of `startTail()` (not after manager construction) so rapid LIVE toggles during a slow backfill no-op the second click instead of spawning a parallel AWS call.

## Test Coverage

New test file `src/stores/panelSlice.test.ts` (392 lines, 12 tests):

```
src/stores/panelSlice.ts startTail()
  [★★★ TESTED] fetch_logs called with ~15m + 2s overlap window
  [★★★ TESTED] logs populated before manager.start
  [★★★ TESTED] isTailing true after backfill + manager.start
  [★★★ TESTED] generic backfill error → toast + manager starts
  [★★★ TESTED] credential error → setConnectionFailed; manager NOT started
                (and isTailing stays true so SSO refresh resumes)
  [★★★ TESTED] seam dedup by event_id
  [★★★ TESTED] seam dedup by timestamp+message[:100]
  [★★★ TESTED] stale fetchId on backfill success discards result
  [★★★ TESTED] stopTail during in-flight backfill prevents manager.start
  [★★★ TESTED] log group switch mid-backfill prevents stale manager.start
  [★★★ TESTED] rapid LIVE toggle blocked by isTailing guard
  [★★★ TESTED] timeout path soft-fails to toast and starts manager

Full suite: 161/161 passing (18 test files)
```

## Pre-Landing Review

5 findings from dual adversarial review (Codex + Claude subagent):
- **[FIXED]** Promise.race 15s timeout leaked a setTimeout on every successful backfill (unhandled rejection). clearTimeout on success and in catch.
- **[FIXED]** SSO refresh callback in workspaceStore.ts skips panels with `isTailing=false`; backfill credential failure left it false, so the panel never resumed live tail post-reconnect. Setting `isTailing=true` at the start of `startTail()` fixes this and the rapid-LIVE-toggle race.
- **[DEFERRED]** Seam-gap > 2s when backfill is slow — accepted trade-off per the autoplan User Challenge (sequential design stays).
- **[DEFERRED]** 100-char message-prefix dedup collision — pre-existing inherited risk.
- **[DEFERRED]** Toast-cleanup setTimeout in error path — guarded by `getPanel()` null check, low impact.

## Plan Completion

Autoplan ran ahead of implementation and approved sequential backfill + hardcoded 15m as v1 design. All 5 P1 must-fix items (seam-gap fix, stopTail fetchId bump, fetchId guard, log-group check, timeout) are implemented and tested. ENG-9 (existing `LiveTailManager.startStream()` catch-path `onTransportChange` omission) is flagged for a separate PR per the autoplan plan.

## Test plan
- [x] Vitest suite: 161/161 passing
- [x] trunk fmt: clean
- [x] trunk lint: clean (203 files)
- [x] tsc + vite build: clean
- [x] Tauri app:build: clean (Loggy.app + .dmg signed, updater key warning unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)